### PR TITLE
Fix float comparisons

### DIFF
--- a/data/float/functions/32/compare/greater/branch0.mcfunction
+++ b/data/float/functions/32/compare/greater/branch0.mcfunction
@@ -2,5 +2,5 @@
 #   Signs are the same
 #
 
-execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io > P5 io run scoreboard players set R0 io 1
+execute if score P1 io > P4 io run scoreboard players set R0 io 1
+execute if score P1 io = P4 io if score P2 io > P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/greater/branch0.mcfunction
+++ b/data/float/functions/32/compare/greater/branch0.mcfunction
@@ -1,0 +1,6 @@
+#> float:32/compare/greater/branch0
+#   Signs are the same
+#
+
+execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io > P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/greater/main.mcfunction
+++ b/data/float/functions/32/compare/greater/main.mcfunction
@@ -12,5 +12,4 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 0 if score P3 io matches 1 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io > P5 io run scoreboard players set R0 io 1
+execute if score P0 io = P3 io run function float:32/compare/greater/branch0

--- a/data/float/functions/32/compare/greater_equal/branch0.mcfunction
+++ b/data/float/functions/32/compare/greater_equal/branch0.mcfunction
@@ -1,0 +1,6 @@
+#> float:32/compare/greater_equal/branch0
+#   Signs are the same
+#
+
+execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io >= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/greater_equal/branch0.mcfunction
+++ b/data/float/functions/32/compare/greater_equal/branch0.mcfunction
@@ -2,5 +2,5 @@
 #   Signs are the same
 #
 
-execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io >= P5 io run scoreboard players set R0 io 1
+execute if score P1 io > P4 io run scoreboard players set R0 io 1
+execute if score P1 io = P4 io if score P2 io >= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/greater_equal/main.mcfunction
+++ b/data/float/functions/32/compare/greater_equal/main.mcfunction
@@ -12,5 +12,4 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 0 if score P3 io matches 1 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io >= P5 io run scoreboard players set R0 io 1
+execute if score P0 io = P3 io run function float:32/compare/greater_equal/branch0

--- a/data/float/functions/32/compare/greater_equal/main.mcfunction
+++ b/data/float/functions/32/compare/greater_equal/main.mcfunction
@@ -12,5 +12,5 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 0 if score P3 io matches 1 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io >= P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io > P4 io run scoreboard players set R0 io 1
 execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io >= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less/branch0.mcfunction
+++ b/data/float/functions/32/compare/less/branch0.mcfunction
@@ -2,5 +2,5 @@
 #   Signs are the same
 #
 
-execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io < P5 io run scoreboard players set R0 io 1
+execute if score P1 io < P4 io run scoreboard players set R0 io 1
+execute if score P1 io = P4 io if score P2 io < P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less/branch0.mcfunction
+++ b/data/float/functions/32/compare/less/branch0.mcfunction
@@ -1,0 +1,6 @@
+#> float:32/compare/less/branch0
+#   Signs are the same
+#
+
+execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io < P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less/main.mcfunction
+++ b/data/float/functions/32/compare/less/main.mcfunction
@@ -12,5 +12,4 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 1 if score P3 io matches 0 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io < P5 io run scoreboard players set R0 io 1
+execute if score P0 io = P3 io run function float:32/compare/less/branch0

--- a/data/float/functions/32/compare/less_equal/branch0.mcfunction
+++ b/data/float/functions/32/compare/less_equal/branch0.mcfunction
@@ -1,0 +1,6 @@
+#> float:32/compare/less_equal/branch0
+#   Signs are the same
+#
+
+execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io <= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less_equal/branch0.mcfunction
+++ b/data/float/functions/32/compare/less_equal/branch0.mcfunction
@@ -2,5 +2,5 @@
 #   Signs are the same
 #
 
-execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io <= P5 io run scoreboard players set R0 io 1
+execute if score P1 io < P4 io run scoreboard players set R0 io 1
+execute if score P1 io = P4 io if score P2 io <= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less_equal/main.mcfunction
+++ b/data/float/functions/32/compare/less_equal/main.mcfunction
@@ -12,5 +12,5 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 1 if score P3 io matches 0 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io <= P4 io run scoreboard players set R0 io 1
+execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
 execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io <= P5 io run scoreboard players set R0 io 1

--- a/data/float/functions/32/compare/less_equal/main.mcfunction
+++ b/data/float/functions/32/compare/less_equal/main.mcfunction
@@ -12,5 +12,4 @@
 #
 scoreboard players set R0 io 0
 execute if score P0 io matches 1 if score P3 io matches 0 run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io < P4 io run scoreboard players set R0 io 1
-execute if score R0 io matches 0 if score P1 io = P4 io if score P2 io <= P5 io run scoreboard players set R0 io 1
+execute if score P0 io = P3 io run function float:32/compare/less/branch0


### PR DESCRIPTION
Fixes #40.

There are two issues with the float comparisons, one is logged ( #40) and the other is not. 
The unlogged issue is that when comparing floats with different signs, only one case is checked, e.g. for `<` the first number is negative and the second is positive. The second case would be the first number is positive and the second is negative, thus the result is false regardless of the exponent/significand values. This PR also fixes this issue.
